### PR TITLE
Add Y/Z swap option for shapefile importer

### DIFF
--- a/456.py
+++ b/456.py
@@ -35,6 +35,7 @@ try:
         ptg.append(StringParmTemplate("target_epsg", "Target CRS (EPSG)", 1, default_value=("EPSG:3857",)))
         ptg.append(StringParmTemplate("attr_prefix", "Attribute Prefix", 1, default_value=("shp_",)))
         ptg.append(ToggleParmTemplate("import_z", "Import Z/M", default_value=False))
+        ptg.append(ToggleParmTemplate("swap_yz", "Swap Y/Z", default_value=False))
         ptg.append(StringParmTemplate("group_by", "Group by DBF Field", 1, default_value=("")))
         pysop.setParmTemplateGroup(ptg)
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # HGIS
 HGIS - Houdini GIS
+
+Simple Houdini Digital Asset for importing ESRI Shapefiles. The node wraps a
+Python implementation inspired by the
+[houdini-sop-shapefile](https://github.com/ttvd/houdini-sop-shapefile)
+project. It relies on the [`pyshp`](https://pypi.org/project/pyshp/) library
+and optionally [`pyproj`](https://pypi.org/project/pyproj/) for reprojection.
+
+Features
+- Create points, polylines and polygons with attributes.
+- Optional reprojection using EPSG codes when a `.prj` file is present.
+- `Swap Y/Z` toggle to flip axes for Y-up shapefiles.

--- a/README_QuickInstall.md
+++ b/README_QuickInstall.md
@@ -24,6 +24,7 @@ Install:
 ## Use
 - Dive into a **Geometry** node, press **Tab**, select **HoudiniGIS → HGIS Shapefile Import**.
 - Pick your `.shp` file. Optionally set `Target CRS (EPSG)` (needs a `.prj` next to the `.shp`).
+- Enable `Swap Y/Z` if your shapefile uses a different up-axis.
 
 ## Notes
 - For polygon holes, subtract group `hgis_hole` from `hgis_exterior` with a **Boolean** SOP.

--- a/nodes/hgis_import_shp_sop_code.py
+++ b/nodes/hgis_import_shp_sop_code.py
@@ -7,6 +7,7 @@ parms = {
     "target_epsg": node.evalParm("target_epsg"),
     "attr_prefix": node.evalParm("attr_prefix"),
     "import_z": bool(node.evalParm("import_z")),
+    "swap_yz": bool(node.evalParm("swap_yz")),
     "group_by": node.evalParm("group_by"),
 }
 mod.import_shp(geo, parms)

--- a/nodes/hgis_pythonmodule.py
+++ b/nodes/hgis_pythonmodule.py
@@ -32,6 +32,7 @@ def import_shp(geo, parms):
     target_epsg = (parms.get("target_epsg","") or "").strip()
     attr_prefix = (parms.get("attr_prefix","") or "shp_")
     import_z = bool(parms.get("import_z", False))
+    swap_yz = bool(parms.get("swap_yz", False))
     group_field = (parms.get("group_by","") or "").strip()
 
     if not shp_path or not os.path.isfile(shp_path):
@@ -47,6 +48,9 @@ def import_shp(geo, parms):
         if transformer:
             x, y = transformer.transform(x, y)
         return x, y
+
+    def make_pos(x, y, z):
+        return hou.Vector3(x, z, y) if swap_yz else hou.Vector3(x, y, z)
 
     r = shapefile.Reader(shp_path)
     fields = r.fields[1:]  # skip deletion flag
@@ -95,7 +99,7 @@ def import_shp(geo, parms):
                 z = c[2] if (import_z and len(c)>=3) else 0.0
                 x,y = tx(x,y)
                 p = geo.createPoint()
-                p.setPosition(hou.Vector3(x,y,z))
+                p.setPosition(make_pos(x,y,z))
                 # push attributes to point for POINT
                 for k,ft in field_meta.items():
                     hname = attr_prefix + k.lower()
@@ -120,7 +124,7 @@ def import_shp(geo, parms):
                 for c in seg:
                     x,y = tx(c[0], c[1])
                     z = c[2] if (import_z and len(c)>=3) else 0.0
-                    pt = geo.createPoint(); pt.setPosition(hou.Vector3(x,y,z))
+                    pt = geo.createPoint(); pt.setPosition(make_pos(x,y,z))
                     poly.addVertex(pt)
                 set_attrs(poly, rec_map)
 
@@ -138,7 +142,7 @@ def import_shp(geo, parms):
                 for c in ring:
                     x,y = tx(c[0], c[1])
                     z = c[2] if (import_z and len(c)>=3) else 0.0
-                    pt = geo.createPoint(); pt.setPosition(hou.Vector3(x,y,z))
+                    pt = geo.createPoint(); pt.setPosition(make_pos(x,y,z))
                     poly.addVertex(pt)
                 set_attrs(poly, rec_map)
                 if is_outer:


### PR DESCRIPTION
## Summary
- allow toggling Y/Z axis swap when importing shapefiles
- document shapefile importer features and swap option

## Testing
- `python -m py_compile nodes/hgis_import_shp_sop_code.py nodes/hgis_pythonmodule.py 456.py`


------
https://chatgpt.com/codex/tasks/task_e_68a617d6132883268a4ccdc44889e548